### PR TITLE
feat: Add player control and actual finish-line race mechanics

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -30,7 +30,10 @@
     <input type="number" id="numRacers" name="numRacers" min="1" value="5">
     <button id="startRaceBtn">Start Race</button>
   </div>
-  <div id="raceTrack"></div>
+  <p id="raceInstructions" class="race-instructions">Press 'ArrowRight' to boost your racer (the first \\(✧ω✧)/)!</p>
+  <div id="raceTrack">
+    <div id="finishLineMarker"></div>
+  </div>
   <p class="text">
    Это легендарная гонка и в ней победит сильнейший.
   </p>
@@ -68,7 +71,7 @@ body {
 /* Styles for Race Setup Area */
 .race-setup {
   background-color: #e9ecef; /* Light grey for setup area */
-  padding: 20px;
+  padding: 10px; /* Reduced padding */
   border-radius: 6px;
   border: 1px solid #ced4da;
   margin-bottom: 25px;
@@ -100,8 +103,22 @@ body {
   transition: background-color 0.3s ease;
 }
 
-.race-setup button:hover {
+.race-setup button:hover:not(:disabled) {
   background-color: #218838; /* Darker green on hover */
+}
+
+.race-setup button:disabled {
+  background-color: #cccccc; /* Grey background when disabled */
+  color: #666666;
+  cursor: not-allowed;
+}
+
+.race-instructions {
+  text-align: center;
+  margin: 10px auto 15px;
+  color: #555;
+  font-style: italic;
+  font-size: 0.9em;
 }
 
 /* Styles for Race Track */
@@ -111,24 +128,40 @@ body {
   width: 90%; /* Keep as is, or adjust if needed */
   min-height: 250px; /* Slightly increased height */
   margin: 20px auto;
-  padding: 15px;
+  padding: 5px; /* Significantly reduced padding */
   border-radius: 6px;
   box-shadow: inset 0 0 10px rgba(0,0,0,0.1); /* Inner shadow for depth */
   position: relative; /* For potential future absolute positioning of elements inside */
 }
 
+#finishLineMarker {
+  position: absolute;
+  right: 10px; /* Positioned slightly from the right edge for visibility */
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background-color: red;
+  box-shadow: 0 0 5px darkred;
+}
+
 /* Styles for Racers */
 .racer {
   display: block; /* Keep as block */
-  margin-bottom: 8px; /* Increased margin */
-  padding: 8px 12px; /* Increased padding */
+  margin-bottom: 8px; /* Keep margin for spacing */
+  padding: 2px 5px; /* Significantly reduced padding */
   background-color: #ffffff; /* White background for racers */
   border: 1px solid #adb5bd;
   border-radius: 4px; /* Softer corners */
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.075); /* Subtle shadow */
   color: #212529;
   font-size: 0.9em;
-  transition: transform 0.2s ease-out, box-shadow 0.2s ease-out; /* Smooth transitions */
+  transition: transform 0.2s ease-out, box-shadow 0.2s ease-out, background-color 0.2s ease; /* Smooth transitions */
+}
+
+.player-racer {
+  border-color: #007bff; /* Blue border */
+  background-color: #e7f3ff; /* Light blue background */
+  box-shadow: 0 0 8px rgba(0,123,255,0.5); /* Blue glow */
 }
 
 .racer:hover { /* Slight hover effect for racers */
@@ -199,23 +232,46 @@ body {
     const startRaceBtn = document.getElementById('startRaceBtn');
     const raceTrackDiv = document.getElementById('raceTrack');
     let racers = []; // Array to store racer elements
+    let isRaceActive = false; // Flag to track if the race is ongoing
+    let playerRacer = null; // To store a reference to the player's racer
 
     startRaceBtn.addEventListener('click', function() {
+      startRaceBtn.disabled = true; // Disable button
+      startRaceBtn.classList.add('disabled');
+
       // Clear previous racers and winner message
-      raceTrackDiv.innerHTML = '';
+      // Ensure finishLineMarker is not cleared by innerHTML
+      const kids = raceTrackDiv.childNodes;
+      for(let i=kids.length-1; i>=0; i--){
+          if(kids[i].id !== 'finishLineMarker'){
+              raceTrackDiv.removeChild(kids[i]);
+          }
+      }
       racers = []; // Reset the array
+      playerRacer = null; // Reset player racer reference
+      isRaceActive = false; // Reset race status
       const existingWinnerMessage = document.getElementById('winnerMessage');
       if (existingWinnerMessage) {
         existingWinnerMessage.remove();
       }
+      
+      // Show instructions if they were hidden
+      // const instructionsEl = document.getElementById('raceInstructions');
+      // if (instructionsEl) instructionsEl.style.display = 'block';
+
 
       const numRacers = parseInt(numRacersInput.value) || 0;
 
       if (numRacers > 0) {
         for (let i = 0; i < numRacers; i++) {
           const racerElement = document.createElement('div');
-          racerElement.textContent = `\\(✧ω✧)/ Racer ${i + 1}`; // Added Racer X for clarity
+          racerElement.textContent = `\\(✧ω✧)/ ${i + 1}`; // Changed text content
           racerElement.className = 'racer';
+          if (i === 0) { // Designate the first racer as player
+            racerElement.isPlayer = true;
+            racerElement.classList.add('player-racer');
+            playerRacer = racerElement; // Store reference
+          }
           // Set a starting position (e.g., left: 0px) for animation later
           racerElement.style.position = 'relative'; // Needed for left positioning
           racerElement.style.left = '0px'; 
@@ -233,94 +289,120 @@ body {
     });
 
     let animationFrameId = null; // To store the requestAnimationFrame ID
+    let winnerDeclared = false; // Flag to ensure only one winner
 
-    function animateRacers(racersArray) {
+    function displayWinner(actualWinner) {
+      isRaceActive = false; // Set race as inactive
       if (animationFrameId) {
-        cancelAnimationFrame(animationFrameId); // Cancel any ongoing animation
+        cancelAnimationFrame(animationFrameId);
       }
+      
+      // Clear previous winner highlights from all racers
+      racers.forEach(r => {
+        r.classList.remove('winner');
+      });
 
-      const finishLine = raceTrackDiv.offsetWidth - 70; // Approx. racer width (adjust if racer style changes)
-      let raceDuration = 5000; // 5 seconds
-      let startTime = null;
-
-      function raceFrame(timestamp) {
-        if (!startTime) {
-          startTime = timestamp;
+      if (actualWinner) {
+        actualWinner.classList.add('winner');
+        
+        // Remove old winner message if exists
+        let winnerMessageEl = document.getElementById('winnerMessage');
+        if (winnerMessageEl) {
+          winnerMessageEl.remove();
         }
 
-        const elapsedTime = timestamp - startTime;
-        let raceOver = elapsedTime >= raceDuration;
+        // Create and display new winner message
+        winnerMessageEl = document.createElement('p');
+        winnerMessageEl.id = 'winnerMessage';
+        winnerMessageEl.textContent = `${actualWinner.textContent} is the WINNER!`;
+        raceTrackDiv.parentNode.insertBefore(winnerMessageEl, raceTrackDiv.nextSibling);
+        console.log(`${actualWinner.textContent} is the WINNER!`);
+      } else {
+        console.log("Race over, but no winner determined (this shouldn't happen in finish line logic).");
+      }
+      startRaceBtn.disabled = false; // Re-enable button
+      startRaceBtn.classList.remove('disabled');
+      // const instructionsEl = document.getElementById('raceInstructions');
+      // if (instructionsEl) instructionsEl.style.display = 'block'; // Show instructions again
+    }
 
+    function animateRacers(racersArray) {
+      isRaceActive = true; 
+      winnerDeclared = false; // Reset winner flag for new race
+      
+      // const instructionsEl = document.getElementById('raceInstructions');
+      // if (instructionsEl) instructionsEl.style.display = 'none'; // Hide instructions during race
+
+      if (animationFrameId) {
+        cancelAnimationFrame(animationFrameId); 
+      }
+
+      const finishLine = raceTrackDiv.offsetWidth; // Finish line is the right edge of the track
+
+      function raceFrame() {
+        if (!isRaceActive || winnerDeclared) { // Stop if race becomes inactive or winner is found
+          cancelAnimationFrame(animationFrameId);
+          return;
+        }
+        
         for (let i = 0; i < racersArray.length; i++) {
           const racer = racersArray[i];
           const currentLeft = parseInt(racer.style.left) || 0;
+          const racerWidth = racer.offsetWidth; // Get actual width of the racer element
 
-          if (currentLeft < finishLine) {
-            const randomIncrement = Math.floor(Math.random() * 5) + 1; // Move 1 to 5 pixels
-            racer.style.left = (currentLeft + randomIncrement) + 'px';
+          // AI movement for all racers (player racer's movement is also influenced by key press)
+          const randomIncrement = Math.floor(Math.random() * 5) + 1; // Move 1 to 5 pixels
+          let newLeft = currentLeft + randomIncrement;
+
+          // Ensure racer does not go beyond finish line due to AI move
+          if (newLeft + racerWidth > finishLine) {
+            newLeft = finishLine - racerWidth;
+          }
+          racer.style.left = newLeft + 'px';
             
-            if ((currentLeft + randomIncrement) >= finishLine) {
-              // Racer crossed the finish line, for this step we just note it
-              // In a future step, we'd handle winner declaration here or ensure they stop
-              console.log(`Racer ${i+1} crossed the finish line.`);
-            }
-          } else {
-            // Racer is already past the finish line, ensure it stays there or slightly past
-            racer.style.left = finishLine + 'px'; 
-          }
-        }
-
-        if (!raceOver) {
-          // Check if all racers have crossed the finish line
-          let allFinished = true;
-          for (let racer of racersArray) {
-            if ((parseInt(racer.style.left) || 0) < finishLine) {
-              allFinished = false;
-              break;
-            }
-          }
-          if (allFinished) {
-            raceOver = true;
-            console.log("All racers have finished!");
+          // Check for winner
+          if (!winnerDeclared && (newLeft + racerWidth >= finishLine)) {
+            winnerDeclared = true;
+            isRaceActive = false; // Stop further input processing and other racers' main logic
+            racer.style.left = (finishLine - racerWidth) + 'px'; // Ensure winner stops exactly at line
+            displayWinner(racer);
+            cancelAnimationFrame(animationFrameId); // Stop animation loop immediately
+            return; // Exit raceFrame, winner found
           }
         }
         
-        if (!raceOver) {
+        if (!winnerDeclared) { // If no winner yet, continue animation
           animationFrameId = requestAnimationFrame(raceFrame);
-        } else {
-          console.log("Race animation finished after duration or all racers crossed.");
-          // Determine and display winner
-          if (racersArray.length > 0) {
-            // Clear previous winner highlights
-            racersArray.forEach(r => {
-              r.classList.remove('winner');
-              // If direct text was added, it would need removal here too.
-              // For this implementation, we are using a class and a separate message element.
-            });
-
-            const winnerIndex = Math.floor(Math.random() * racersArray.length);
-            const winner = racersArray[winnerIndex];
-            
-            winner.classList.add('winner');
-
-            // Remove old winner message if exists
-            let winnerMessageEl = document.getElementById('winnerMessage');
-            if (winnerMessageEl) {
-              winnerMessageEl.remove();
-            }
-
-            // Create and display new winner message
-            winnerMessageEl = document.createElement('p');
-            winnerMessageEl.id = 'winnerMessage';
-            winnerMessageEl.textContent = `${winner.textContent.split(' Racer')[0]} \\(✧ω✧)/ is the WINNER!`; // Get original text part
-            
-            // Insert winner message after raceTrackDiv
-            raceTrackDiv.parentNode.insertBefore(winnerMessageEl, raceTrackDiv.nextSibling);
-          }
         }
       }
       animationFrameId = requestAnimationFrame(raceFrame);
     }
+
+    // Keyboard control for player racer
+    document.addEventListener('keydown', function(event) {
+      if (event.key === 'ArrowRight' && isRaceActive && playerRacer && !winnerDeclared) {
+        const currentLeft = parseInt(playerRacer.style.left) || 0;
+        const boostAmount = 20; // Increased boost amount
+        const racerWidth = playerRacer.offsetWidth;
+        const finishLine = raceTrackDiv.offsetWidth; 
+
+        let newPos = currentLeft + boostAmount;
+
+        if (newPos + racerWidth > finishLine) {
+          newPos = finishLine - racerWidth; // Stop exactly at the line
+          // Player might win due to this boost
+          if (!winnerDeclared) {
+            winnerDeclared = true;
+            isRaceActive = false;
+            playerRacer.style.left = newPos + 'px';
+            displayWinner(playerRacer);
+            cancelAnimationFrame(animationFrameId);
+            return;
+          }
+        }
+        playerRacer.style.left = newPos + 'px';
+      }
+    });
   });
 </script>
 </html>


### PR DESCRIPTION
This commit significantly updates the \(✧ω✧)/ racing game:

- Player Control: The first \(✧ω✧)/ is now player-controlled using the 'ArrowRight' key for a speed boost. The player's racer is visually distinct.
- Actual Race Logic: The winner is determined by the first racer to cross a visual finish line. Random winner selection has been removed.
- Styling Adjustments: Padding has been reduced as per your feedback, and the word "Racer" is no longer used in racer display text.
- Visual Feedback:
    - Added on-screen instructions for player control.
    - Added a visual marker for the finish line.
    - The "Start Race" button is now disabled during an active race.
- The game remains entirely within index.htm.